### PR TITLE
Support for sqlx-postgres and the annotation `refinery:noTransaction`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 Refinery.toml
 target/
 Cargo.lock
+
+# dev
+.dir-locals.el

--- a/examples/src/main.rs
+++ b/examples/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(unused_imports)]
 use barrel::backend::Sqlite as Sql;
 use log::info;
 use refinery::Migration;

--- a/refinery_core/Cargo.toml
+++ b/refinery_core/Cargo.toml
@@ -14,6 +14,7 @@ rusqlite-bundled = ["rusqlite", "rusqlite/bundled"]
 tiberius = ["dep:tiberius", "futures", "tokio", "tokio/net"]
 tiberius-config = ["tiberius", "tokio", "tokio-util", "serde"]
 tokio-postgres = ["dep:tokio-postgres", "tokio", "tokio/rt"]
+sqlx-postgres = ["dep:sqlx", "futures", "sqlx/postgres", "sqlx/time"]
 mysql_async = ["dep:mysql_async"]
 serde = ["dep:serde"]
 toml = ["serde", "dep:toml"]
@@ -40,6 +41,11 @@ futures = { version = "0.3.16", optional = true, features = ["async-await"] }
 tokio-util = { version = "0.7.7", features = ["compat"], optional = true }
 time = { version = "0.3.5", features = ["parsing", "formatting"] }
 serde = { version = "1", features = ["derive"], optional = true }
+# Has to be sqlx >= 0.8.0 because this crate transitively depends on
+# `libsqlite3-sys` and sqlx brings in an incompatible version of that
+# otherwise, even though features say it shouldn't, because of an open
+# issue in cargo; see https://github.com/launchbadge/sqlx/issues/3211
+sqlx = { version = "0.8", optional = true }
 toml = { version = "0.8.8", optional = true }
 
 [dev-dependencies]

--- a/refinery_core/src/config.rs
+++ b/refinery_core/src/config.rs
@@ -279,6 +279,7 @@ struct Main {
     feature = "mysql",
     feature = "postgres",
     feature = "tokio-postgres",
+    feature = "sqlx-postgres",
     feature = "mysql_async"
 ))]
 pub(crate) fn build_db_url(name: &str, config: &Config) -> String {

--- a/refinery_core/src/drivers/mod.rs
+++ b/refinery_core/src/drivers/mod.rs
@@ -16,4 +16,7 @@ pub mod mysql;
 #[cfg(feature = "tiberius")]
 pub mod tiberius;
 
+#[cfg(feature = "sqlx-postgres")]
+pub mod sqlx_postgres;
+
 mod config;

--- a/refinery_core/src/drivers/mysql_async.rs
+++ b/refinery_core/src/drivers/mysql_async.rs
@@ -1,5 +1,5 @@
-use crate::traits::r#async::{AsyncMigrate, AsyncQuery, AsyncTransaction};
-use crate::Migration;
+use crate::traits::r#async::{AsyncExecutor, AsyncMigrate, AsyncQuerySchemaHistory};
+use crate::{Migration, MigrationContent};
 use async_trait::async_trait;
 use mysql_async::{
     prelude::Queryable, Error as MError, IsolationLevel, Pool, Transaction as MTransaction, TxOpts,
@@ -36,41 +36,70 @@ async fn query_applied_migrations<'a>(
 }
 
 #[async_trait]
-impl AsyncTransaction for Pool {
+impl AsyncExecutor for Pool {
     type Error = MError;
 
-    async fn execute<'a, T: Iterator<Item = &'a str> + Send>(
+    async fn execute_grouped<'a, T: Iterator<Item = &'a str> + Send>(
         &mut self,
         queries: T,
     ) -> Result<usize, Self::Error> {
-        let mut conn = self.get_conn().await?;
-        let mut options = TxOpts::new();
-        options.with_isolation_level(Some(IsolationLevel::ReadCommitted));
-
-        let mut transaction = conn.start_transaction(options).await?;
-        let mut count = 0;
+        let tx_opts = TxOpts::default()
+            .with_isolation_level(Some(IsolationLevel::ReadCommitted))
+            .clone();
+        let mut tx = self.start_transaction(tx_opts).await?;
+        let mut count: usize = 0;
         for query in queries {
-            transaction.query_drop(query).await?;
+            tx.query_drop(query).await?;
             count += 1;
         }
-        transaction.commit().await?;
-        Ok(count as usize)
+        tx.commit().await?;
+
+        Ok(count)
+    }
+
+    async fn execute<'a, T>(&mut self, queries: T) -> Result<usize, Self::Error>
+    where
+        T: Iterator<Item = (&'a MigrationContent, &'a str)> + Send,
+    {
+        let mut count: usize = 0;
+        for (content, update) in queries {
+            let mut conn = self.get_conn().await?;
+            if content.no_transaction() {
+                conn.query_drop(content.sql()).await?;
+                if let Err(e) = conn.query_drop(update).await {
+                    log::error!("applied migration but schema history table update failed");
+                    return Err(e);
+                };
+                count += 2;
+            } else {
+                let tx_opts = TxOpts::default()
+                    .with_isolation_level(Some(IsolationLevel::ReadCommitted))
+                    .clone();
+                let mut tx = self.start_transaction(tx_opts).await?;
+                tx.query_drop(content.sql()).await?;
+                tx.query_drop(update).await?;
+                tx.commit().await?;
+                count += 2;
+            }
+        }
+
+        Ok(count)
     }
 }
 
 #[async_trait]
-impl AsyncQuery<Vec<Migration>> for Pool {
-    async fn query(
+impl AsyncQuerySchemaHistory<Vec<Migration>> for Pool {
+    async fn query_schema_history(
         &mut self,
         query: &str,
-    ) -> Result<Vec<Migration>, <Self as AsyncTransaction>::Error> {
-        let mut conn = self.get_conn().await?;
-        let mut options = TxOpts::new();
-        options.with_isolation_level(Some(IsolationLevel::ReadCommitted));
-        let transaction = conn.start_transaction(options).await?;
+    ) -> Result<Vec<Migration>, <Self as AsyncExecutor>::Error> {
+        let tx_opts = TxOpts::default()
+            .with_isolation_level(Some(IsolationLevel::ReadCommitted))
+            .clone();
+        let tx = self.start_transaction(tx_opts).await?;
+        let (tx, applied) = query_applied_migrations(tx, query).await?;
+        tx.commit().await?;
 
-        let (transaction, applied) = query_applied_migrations(transaction, query).await?;
-        transaction.commit().await?;
         Ok(applied)
     }
 }

--- a/refinery_core/src/drivers/sqlx_postgres.rs
+++ b/refinery_core/src/drivers/sqlx_postgres.rs
@@ -1,0 +1,95 @@
+use async_trait::async_trait;
+use futures::prelude::*;
+use sqlx::{Acquire, PgPool, Postgres};
+use time::OffsetDateTime;
+
+use crate::traits::r#async::{AsyncExecutor, AsyncMigrate, AsyncQuerySchemaHistory};
+use crate::{Migration, MigrationContent};
+
+/// A representation of a row in the schema
+/// history table where migrations are persisted.
+#[derive(Debug, Clone, sqlx::FromRow)]
+struct SchemaHistory {
+    version: i32,
+    name: String,
+    applied_on: Option<OffsetDateTime>,
+    checksum: i64,
+}
+
+async fn query_applied_migrations(
+    pool: &PgPool,
+    query: &str,
+) -> Result<Vec<Migration>, sqlx::Error> {
+    sqlx::query_as::<Postgres, SchemaHistory>(query)
+        .fetch(pool)
+        .map_ok(|r| {
+            Migration::applied(
+                r.version,
+                r.name,
+                r.applied_on
+                    .expect("applied migration missing `applied_on`"),
+                u64::try_from(r.checksum).expect("checksum not u64"),
+            )
+        })
+        .try_collect::<Vec<Migration>>()
+        .await
+}
+
+#[async_trait]
+impl AsyncExecutor for PgPool {
+    type Error = sqlx::Error;
+
+    async fn execute_grouped<'a, T: Iterator<Item = &'a str> + Send>(
+        &mut self,
+        queries: T,
+    ) -> Result<usize, Self::Error> {
+        let mut tx = self.begin().await?;
+        let mut count: usize = 0;
+        for q in queries {
+            let conn = tx.acquire().await?;
+            sqlx::query(q).execute(&mut *conn).await?;
+            count += 1;
+        }
+        tx.commit().await?;
+
+        Ok(count)
+    }
+
+    async fn execute<'a, T>(&mut self, queries: T) -> Result<usize, Self::Error>
+    where
+        T: Iterator<Item = (&'a MigrationContent, &'a str)> + Send,
+    {
+        let mut count: usize = 0;
+        for (content, update) in queries {
+            if content.no_transaction() {
+                let mut conn = self.acquire().await?;
+                sqlx::query(content.sql()).execute(&mut *conn).await?;
+                if let Err(e) = sqlx::query(update).execute(&mut *conn).await {
+                    log::error!("applied migration but schema history table update failed");
+                    return Err(e);
+                };
+                count += 2;
+            } else {
+                let mut tx = self.begin().await?;
+                let conn = tx.acquire().await?;
+                sqlx::query(content.sql()).execute(&mut *conn).await?;
+                sqlx::query(update).execute(&mut *conn).await?;
+                tx.commit().await?;
+                count += 2;
+            }
+        }
+
+        Ok(count)
+    }
+}
+
+#[async_trait]
+impl AsyncQuerySchemaHistory<Vec<Migration>> for PgPool {
+    async fn query_schema_history(&mut self, query: &str) -> Result<Vec<Migration>, sqlx::Error> {
+        let applied = query_applied_migrations(&self, query).await?;
+
+        Ok(applied)
+    }
+}
+
+impl AsyncMigrate for PgPool {}

--- a/refinery_core/src/lib.rs
+++ b/refinery_core/src/lib.rs
@@ -6,11 +6,12 @@ pub mod traits;
 mod util;
 
 pub use crate::error::Error;
-pub use crate::runner::{Migration, Report, Runner, Target};
+pub use crate::runner::{Migration, MigrationContent, Report, Runner, Target};
 pub use crate::traits::r#async::AsyncMigrate;
 pub use crate::traits::sync::Migrate;
 pub use crate::util::{
-    find_migration_files, load_sql_migrations, parse_migration_name, MigrationType,
+    find_migration_files, load_sql_migrations, parse_migration_name, parse_no_transaction,
+    MigrationType,
 };
 
 #[cfg(feature = "rusqlite")]
@@ -30,3 +31,8 @@ pub use mysql_async;
 
 #[cfg(feature = "tiberius")]
 pub use tiberius;
+
+#[cfg(feature = "sqlx-postgres")]
+pub mod sqlx_postgres {
+    pub use sqlx::postgres::*;
+}

--- a/refinery_core/src/traits/sync.rs
+++ b/refinery_core/src/traits/sync.rs
@@ -1,37 +1,60 @@
-use std::ops::Deref;
-
 use crate::error::WrapMigrationError;
 use crate::traits::{
     insert_migration_query, verify_migrations, ASSERT_MIGRATIONS_TABLE_QUERY,
     GET_APPLIED_MIGRATIONS_QUERY, GET_LAST_APPLIED_MIGRATION_QUERY,
 };
-use crate::{Error, Migration, Report, Target};
+use crate::{Error, Migration, MigrationContent, Report, Target};
 
-pub trait Transaction {
+pub trait Executor {
     type Error: std::error::Error + Send + Sync + 'static;
 
-    fn execute<'a, T: Iterator<Item = &'a str>>(
+    /// Runs a collection of migrations in one transaction.  The user
+    /// implementing this trait is responsible for the guarantee that
+    /// that is correctly done.
+    fn execute_grouped<'a, T: Iterator<Item = &'a str>>(
         &mut self,
         queries: T,
     ) -> Result<usize, Self::Error>;
+
+    /// Run a set of tuples of the migration query and the query to update the
+    /// schema history table on success. This is done in order but not all
+    /// together in one transaction. An individual query may be ran in a
+    /// transaction according to the `no_transaction` field of the migration
+    /// content struct. If a schema history update query fails, the migration
+    /// cycle is halted there.
+    fn execute<'a, T>(&mut self, queries: T) -> Result<usize, Self::Error>
+    where
+        T: Iterator<Item = (&'a MigrationContent, &'a str)>;
 }
 
-pub trait Query<T>: Transaction {
-    fn query(&mut self, query: &str) -> Result<T, Self::Error>;
+pub trait QuerySchemaHistory<T>: Executor {
+    fn query_schema_history(&mut self, query: &str) -> Result<T, Self::Error>;
 }
 
-pub fn migrate<T: Transaction>(
-    transaction: &mut T,
+pub fn migrate<T: Executor>(
+    executor: &mut T,
     migrations: Vec<Migration>,
     target: Target,
     migration_table_name: &str,
     grouped: bool,
 ) -> Result<Report, Error> {
-    let mut migration_batch = Vec::new();
-    let mut applied_migrations = Vec::new();
+    if grouped {
+        migrate_grouped(executor, migrations, target, migration_table_name)
+    } else {
+        migrate_individual(executor, migrations, target, migration_table_name)
+    }
+}
+
+fn migrate_individual<T: Executor>(
+    executor: &mut T,
+    migrations: Vec<Migration>,
+    target: Target,
+    migration_table_name: &str,
+) -> Result<Report, Error> {
+    let mut applied_migrations = vec![];
 
     for mut migration in migrations.into_iter() {
-        if let Target::Version(input_target) | Target::FakeVersion(input_target) = target {
+        if let Target::Version(input_target) = target {
             if input_target < migration.version() {
                 log::info!(
                     "stopping at migration: {}, due to user option",
@@ -43,59 +66,89 @@ pub fn migrate<T: Transaction>(
 
         log::info!("applying migration: {}", migration);
         migration.set_applied();
-        let insert_migration = insert_migration_query(&migration, migration_table_name);
-        let migration_sql = migration.sql().expect("sql must be Some!").to_string();
+        let update_query = insert_migration_query(&migration, migration_table_name);
+        executor
+            .execute(
+                [(
+                    migration.content().expect("migration has no content"),
+                    update_query.as_str(),
+                )]
+                .into_iter(),
+            )
+            .migration_err(
+                &format!("error applying migration {}", migration),
+                Some(&applied_migrations),
+            )?;
+        applied_migrations.push(migration);
+    }
+    Ok(Report::new(applied_migrations))
+}
+
+fn migrate_grouped<T: Executor>(
+    executor: &mut T,
+    migrations: Vec<Migration>,
+    target: Target,
+    migration_table_name: &str,
+) -> Result<Report, Error> {
+    let mut grouped_migrations = Vec::new();
+    let mut applied_migrations = Vec::new();
+
+    for mut migration in migrations.into_iter() {
+        if let Target::Version(input_target) | Target::FakeVersion(input_target) = target {
+            if input_target < migration.version() {
+                break;
+            }
+        }
+
+        migration.set_applied();
+        let query = insert_migration_query(&migration, migration_table_name);
+
+        let sql = migration.sql().expect("sql must be Some!");
 
         // If Target is Fake, we only update schema migrations table
         if !matches!(target, Target::Fake | Target::FakeVersion(_)) {
             applied_migrations.push(migration);
-            migration_batch.push(migration_sql);
+            grouped_migrations.push(sql);
         }
-        migration_batch.push(insert_migration);
+        grouped_migrations.push(query);
     }
 
-    match (target, grouped) {
-        (Target::Fake | Target::FakeVersion(_), _) => {
+    match target {
+        Target::Fake | Target::FakeVersion(_) => {
             log::info!("not going to apply any migration as fake flag is enabled");
         }
-        (Target::Latest | Target::Version(_), true) => {
+        Target::Latest | Target::Version(_) => {
             log::info!(
                 "going to apply batch migrations in single transaction: {:#?}",
                 applied_migrations.iter().map(ToString::to_string)
             );
         }
-        (Target::Latest | Target::Version(_), false) => {
-            log::info!(
-                "preparing to apply {} migrations: {:#?}",
-                applied_migrations.len(),
-                applied_migrations.iter().map(ToString::to_string)
-            );
-        }
     };
 
-    if grouped {
-        transaction
-            .execute(migration_batch.iter().map(Deref::deref))
-            .migration_err("error applying migrations", None)?;
-    } else {
-        for (i, update) in migration_batch.into_iter().enumerate() {
-            transaction
-                .execute([update.as_str()].into_iter())
-                .migration_err("error applying update", Some(&applied_migrations[0..i / 2]))?;
-        }
+    if let Target::Version(input_target) = target {
+        log::info!(
+            "stopping at migration: {}, due to user option",
+            input_target
+        );
     }
+
+    let refs = grouped_migrations.iter().map(AsRef::as_ref);
+
+    executor
+        .execute_grouped(refs)
+        .migration_err("error applying migrations", None)?;
 
     Ok(Report::new(applied_migrations))
 }
 
-pub trait Migrate: Query<Vec<Migration>>
+pub trait Migrate: QuerySchemaHistory<Vec<Migration>>
 where
     Self: Sized,
 {
     fn assert_migrations_table(&mut self, migration_table_name: &str) -> Result<usize, Error> {
         // Needed cause some database vendors like Mssql have a non sql standard way of checking the migrations table,
-        // thou on this case it's just to be consistent with the async trait `AsyncMigrate`
-        self.execute(
+        // thouh in this case it's just to be consistent with the async trait `AsyncMigrate`
+        self.execute_grouped(
             [ASSERT_MIGRATIONS_TABLE_QUERY
                 .replace("%MIGRATION_TABLE_NAME%", migration_table_name)
                 .as_str()]
@@ -109,7 +162,7 @@ where
         migration_table_name: &str,
     ) -> Result<Option<Migration>, Error> {
         let mut migrations = self
-            .query(
+            .query_schema_history(
                 &GET_LAST_APPLIED_MIGRATION_QUERY
                     .replace("%MIGRATION_TABLE_NAME%", migration_table_name),
             )
@@ -123,7 +176,7 @@ where
         migration_table_name: &str,
     ) -> Result<Vec<Migration>, Error> {
         let migrations = self
-            .query(
+            .query_schema_history(
                 &GET_APPLIED_MIGRATIONS_QUERY
                     .replace("%MIGRATION_TABLE_NAME%", migration_table_name),
             )
@@ -174,9 +227,9 @@ where
         )?;
 
         if grouped || matches!(target, Target::Fake | Target::FakeVersion(_)) {
-            migrate(self, migrations, target, migration_table_name, true)
+            migrate_grouped(self, migrations, target, migration_table_name)
         } else {
-            migrate(self, migrations, target, migration_table_name, false)
+            migrate_individual(self, migrations, target, migration_table_name)
         }
     }
 }


### PR DESCRIPTION
- Required implementations to use `sqlx::PgPool` as the driver for embedded Rust migrations.
- Addresses https://github.com/rust-db/refinery/issues/277 by adding the ability to annotate a SQL or Rust migration with `refinery:noTransaction`, which will make the migration be applied outside of a transaction when not grouping unapplied migrations.  